### PR TITLE
fix(install-service): Use sc.exe in-place of ps 6 commands 

### DIFF
--- a/service-example/README.md
+++ b/service-example/README.md
@@ -5,6 +5,6 @@ This example demonstrates how to use the Rainway SDK in a C# console app that be
 For detailed explanation of how everything works read the comments in [Program.cs](Program.cs#L11), all the corresponding documentation.
 
 To test this project provide your API key to the `RainwayConfig` and then use the two scripts included:
-- `install-service.ps1` which will build the project and install it as a Windows service
+- `install-service.ps1` which will build the project and install it as a Windows service. Requires administrative access.
 - `start-service.ps1` which will start the service and passthrough any arguments supplied to the script
 


### PR DESCRIPTION
`Remove-Service` and `Set-Service` is ps6 only, which still is not the os default version. As a result, fall back to `sc.exe` for missing commands here, since we already depend on it elsewhere.
- https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4510
- https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/install/windows-powershell-system-requirements?view=powershell-7.2#windows-powershell-51


Update readme to clarify `install-service.ps1` requires admin perms.
Add logging of user SID for clarity.