### PR TITLE
feat(upgrade): Upgrade to `0.2.1` sdk build

### DIFF
--- a/service-example/service-example.csproj
+++ b/service-example/service-example.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="rainway-sdk" Version="0.2.0" />
+    <PackageReference Include="rainway-sdk" Version="0.2.1" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
     <PackageReference Include="Warden.NET" Version="6.0.6" />


### PR DESCRIPTION
This build fixes an issue with enhanced pointer precision failing to be disabled when a stream starts. This is a backward compatible fix.