### PR TITLE
fix(packaging): Use `build` not `publish`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,60 +2,61 @@ name: CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
-
 
 jobs:
   build_and_release:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
 
-    - name: Publish host-example
-      run: dotnet publish -c release -r win-x64 --self-contained true -o ../bin/host-example host-example.csproj
-      working-directory: host-example
+      - name: Create bin
+        run: mkdir bin
 
-    - name: Publish host-service-example
-      run: dotnet publish -c release -r win-x64 --self-contained true -o ../bin/host-service-example service-example.csproj
-      working-directory: host-service-example
+      - name: Build host-example
+        run: dotnet build -c release host-example.csproj && cp -R bin/ ../bin/host-example/
+        working-directory: host-example
 
-    # Locally we debug the build output
-    - name: List bin (local only)
-      if: ${{ env.ACT }}
-      run: ls -alR bin
+      - name: Build host-service-example
+        run: dotnet build -c release service-example.csproj && cp -R bin/ ../bin/host-service-example/
+        working-directory: host-service-example
 
-    - name: Parse git commit
-      run: echo GH_REL_TAG=$(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/v0-\1/") >> $GITHUB_ENV
+      # Locally we debug the build output
+      - name: List bin (local only)
+        if: ${{ env.ACT }}
+        run: ls -alR bin
 
-    # Locally we debug the tag parse
-    - run: echo ${{ env.GH_REL_TAG }}
-      if: ${{ env.ACT }}
+      - name: Parse git commit
+        run: echo GH_REL_TAG=$(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/v0-\1/") >> $GITHUB_ENV
 
-    # Remotely we create and push the tag
-    - name: Create Release Tag
-      run: git tag ${{ env.GH_REL_TAG }} && git push origin ${{ env.GH_REL_TAG }}
-      if: ${{ !env.ACT }}
+      # Locally we debug the tag parse
+      - run: echo ${{ env.GH_REL_TAG }}
+        if: ${{ env.ACT }}
 
-    - name: Package bin
-      run: |
-        mkdir rel
-        zip rel/host-example-${{ env.GH_REL_TAG }}.zip -r bin/host-example &&
-        zip rel/host-service-example-${{ env.GH_REL_TAG }}.zip -r bin/host-service-example &&
-        echo "Packaged."
+      # Remotely we create and push the tag
+      - name: Create Release Tag
+        run: git tag ${{ env.GH_REL_TAG }} && git push origin ${{ env.GH_REL_TAG }}
+        if: ${{ !env.ACT }}
 
-    # Remotely we create the release from the tag
-    - name: GH Release
-      if: ${{ !env.ACT }}
-      uses: softprops/action-gh-release@v0.1.14
-      with:
-        tag_name: ${{ env.GH_REL_TAG }}
-        generate_release_notes: true
-        files: rel/*.zip
+      - name: Package bin
+        run: |
+          mkdir rel
+          zip rel/host-example-${{ env.GH_REL_TAG }}.zip -r bin/host-example &&
+          zip rel/host-service-example-${{ env.GH_REL_TAG }}.zip -r bin/host-service-example &&
+          echo "Packaged."
+
+      # Remotely we create the release from the tag
+      - name: GH Release
+        if: ${{ !env.ACT }}
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          tag_name: ${{ env.GH_REL_TAG }}
+          generate_release_notes: true
+          files: rel/*.zip


### PR DESCRIPTION
Resolves an issue with packaging that caused Release zips to contain an invalid directory layout. This led to missing native dll issues. Instead of `publish`, use `build`, which retains the build directory layout.

Without this, customers would not have succeeded running from the artifact zip.