### PR TITLE
fix(CD): Use windows builder for CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,17 +28,10 @@ jobs:
         run: dotnet build -c release service-example.csproj && cp -R bin/ ../bin/host-service-example/
         working-directory: host-service-example
 
-      # Locally we debug the build output
-      - name: List bin (local only)
-        if: ${{ env.ACT }}
-        run: ls -alR bin
-
       - name: Parse git commit
         run: $env:GITHUB_ENV = echo GH_REL_TAG=$(git rev-parse --short HEAD)
 
-      # Locally we debug the tag parse
       - run: echo ${{ env.GH_REL_TAG }}
-        if: ${{ env.ACT }}
 
       # Remotely we create and push the tag
       - name: Create Release Tag

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
         run: ls -alR bin
 
       - name: Parse git commit
-        run: echo GH_REL_TAG=$(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/v0-\1/") >> $GITHUB_ENV
+        run: $env:GITHUB_ENV = echo GH_REL_TAG=$(git rev-parse --short HEAD)
 
       # Locally we debug the tag parse
       - run: echo ${{ env.GH_REL_TAG }}
@@ -48,8 +48,8 @@ jobs:
       - name: Package bin
         run: |
           mkdir rel
-          zip rel/host-example-${{ env.GH_REL_TAG }}.zip -r bin/host-example &&
-          zip rel/host-service-example-${{ env.GH_REL_TAG }}.zip -r bin/host-service-example &&
+          Compress-Archive -DestinationPath rel/host-example-${{ env.GH_REL_TAG }}.zip -Path bin/host-example &&
+          Compress-Archive -DestinationPath rel/host-service-example-${{ env.GH_REL_TAG }}.zip -Path bin/host-service-example &&
           echo "Packaged."
 
       # Remotely we create the release from the tag

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: host-service-example
 
       - name: Parse git commit
-        run: echo GH_REL_TAG=$(git rev-parse --short HEAD) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: echo GH_REL_TAG=v0-$(git rev-parse --short HEAD) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: echo ${{ env.GH_REL_TAG }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: host-service-example
 
       - name: Parse git commit
-        run: $env:GITHUB_ENV = echo GH_REL_TAG=$(git rev-parse --short HEAD)
+        run: echo GH_REL_TAG=$(git rev-parse --short HEAD) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: echo ${{ env.GH_REL_TAG }}
 


### PR DESCRIPTION
Until Rainway supports self-contained binaries (Which is a current backlog item) we need to use windows for the CD artifacts, as "cross-compilation" (e.g. `dotnet publish -r <runtime_id>`) depends on that.

When we initially swapped to `dotnet build` we didn't catch this, and produced an invalid release artifact. As a quick fix, I'd manually created the binary for that release, but this was the missing ingredient to get automated CD working correctly again.

Once we support self-contained binaries, we should revert this as `ubuntu-latest` actions runners are cheaper.