### PR TITLE
feat(cd): Stabilize release artifact names

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Package bin
         run: |
           mkdir rel
-          Compress-Archive -DestinationPath rel/host-example-${{ env.GH_REL_TAG }}.zip -Path bin/host-example &&
-          Compress-Archive -DestinationPath rel/host-service-example-${{ env.GH_REL_TAG }}.zip -Path bin/host-service-example &&
+          Compress-Archive -DestinationPath rel/host-example.zip -Path bin/host-example &&
+          Compress-Archive -DestinationPath rel/host-service-example.zip -Path bin/host-service-example &&
           echo "Packaged."
 
       # Remotely we create the release from the tag


### PR DESCRIPTION
This PR aims to stabilize the names of release artifacts to `project_dir.zip` for example `host-example.zip`. This should make them easier to consume by automated systems.

Will need to update https://docs.rainway.com/docs/what-is-rainway after this lands