### PR TITLE
fix(version): Support string versions

### DIFF
--- a/host-example-core/HostExample.cs
+++ b/host-example-core/HostExample.cs
@@ -79,7 +79,7 @@ namespace Rainway.HostExample
         /// <summary>
         /// If connected: get the Rainway SDK version.
         /// </summary>
-        public Version? Version => new Version(RainwaySDK.Version);
+        public string Version => RainwaySDK.Version;
 
         /// <summary>
         /// A publicly settable property that determines whether to accept


### PR DESCRIPTION
Looks like this was missed when we introduced full semver versions (e.g. `0.5.0-beta.1`)